### PR TITLE
Add support for transforming a tuple type to an option type, when required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         ],
     install_requires = [
        'dbus-python',
-       'into-dbus-python>=0.03'
+       'into-dbus-python>=0.05'
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),

--- a/src/stratisd_client_dbus/_connection.py
+++ b/src/stratisd_client_dbus/_connection.py
@@ -30,7 +30,7 @@ class Bus(object):
     _BUS = None
 
     @staticmethod
-    def get_bus():
+    def get_bus(): # pragma: no cover
         """
         Get our bus.
         """
@@ -39,7 +39,7 @@ class Bus(object):
 
         return Bus._BUS
 
-def get_object(object_path):
+def get_object(object_path): # pragma: no cover
     """
     Get an object from an object path.
 

--- a/tests/dbus/manager/test_destroy.py
+++ b/tests/dbus/manager/test_destroy.py
@@ -160,7 +160,7 @@ class Destroy3TestCase(unittest.TestCase):
         )
         Pool.CreateFilesystems(
            get_object(poolpath),
-           specs=[(self._VOLNAME, '', 0)]
+           specs=[(self._VOLNAME, '', None)]
         )
         Manager.ConfigureSimulator(self._proxy, denominator=8)
 

--- a/tests/dbus/manager/test_object_path.py
+++ b/tests/dbus/manager/test_object_path.py
@@ -259,7 +259,7 @@ class GetVolume2TestCase(unittest.TestCase):
         )
         Pool.CreateFilesystems(
            get_object(poolpath),
-           specs=[(self._VOLNAME, '', 0)]
+           specs=[(self._VOLNAME, '', None)]
         )
 
     def tearDown(self):

--- a/tests/dbus/pool/test_create_filesystem.py
+++ b/tests/dbus/pool/test_create_filesystem.py
@@ -120,7 +120,7 @@ class CreateFSTestCase1(unittest.TestCase):
         self._pool_object = get_object(result)
         Pool.CreateFilesystems(
            self._pool_object,
-           specs=[(self._VOLNAME, '', 0)]
+           specs=[(self._VOLNAME, '', None)]
         )
         Manager.ConfigureSimulator(self._proxy, denominator=8)
 
@@ -139,7 +139,7 @@ class CreateFSTestCase1(unittest.TestCase):
         (result, rc, _) = checked_call(
            Pool.CreateFilesystems(
               self._pool_object,
-              specs=[(self._VOLNAME, "", 0)]
+              specs=[(self._VOLNAME, "", None)]
            ),
            PoolSpec.OUTPUT_SIGS[_PN.CreateFilesystems]
         )

--- a/tests/dbus/pool/test_destroy_filesystem.py
+++ b/tests/dbus/pool/test_destroy_filesystem.py
@@ -139,7 +139,7 @@ class DestroyFSTestCase1(unittest.TestCase):
         self._pool_object = get_object(result)
         Pool.CreateFilesystems(
            self._pool_object,
-           specs=[(self._VOLNAME, '', 0)]
+           specs=[(self._VOLNAME, '', None)]
         )
         Manager.ConfigureSimulator(self._proxy, denominator=8)
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
 commands =
     coverage --version
     coverage run --timid --branch -m pytest tests/unit
-    coverage report -m --fail-under=90 --show-missing --include="{envsitepackagesdir}/stratisd_client_dbus/*"
+    coverage report -m --fail-under=100 --show-missing --include="{envsitepackagesdir}/stratisd_client_dbus/*"
     coverage html --include="{envsitepackagesdir}/stratisd_client_dbus/*"
 
 [testenv:lint]


### PR DESCRIPTION
Use xformers() method from in into-dbus-python v0.05.

Put pragma's wherever tests would require actually starting dbus.
We don't try to do this on Travis CI and it is more informative to have 100%
coverage and pragma annotations than less coverage and no annotations.

Make xformer function slightly more sophisticated; there is now a front-end
transformer that does things like tuple to option and a back-end xformer
for transformation to dbus-python types.

Change src so that CreateFilesystems quota part of filesystem spec is
treated as an option type.

Change tests so that CreateFilesystems tests pass None everywhere, meaning
"accept default", for quota.

Signed-off-by: mulhern <amulhern@redhat.com>