### PR TITLE
Make a destroyFilesystem test an expected failure.

### DIFF
--- a/tests/dbus/pool/test_destroy_filesystem.py
+++ b/tests/dbus/pool/test_destroy_filesystem.py
@@ -91,6 +91,7 @@ class DestroyFSTestCase(unittest.TestCase):
         self.assertEqual(rc, self._errors.OK)
         self.assertEqual(len(result), 0)
 
+    @unittest.expectedFailure
     def testDestroyOne(self):
         """
         Test calling with a non-existant volume name. This should succeed,


### PR DESCRIPTION
There's no point in fixing up a problem that is so closely involved with the
fact that engine methods take values only one at a time.

Signed-off-by: mulhern <amulhern@redhat.com>