### PR TITLE
Update to new version of into-dbus-python.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         ],
     install_requires = [
        'dbus-python',
-       'into-dbus-python>=0.05'
+       'into-dbus-python>=0.06'
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),

--- a/tests/dbus/_misc.py
+++ b/tests/dbus/_misc.py
@@ -43,6 +43,18 @@ def checked_call(value, sig):
         raise ValueError("result type does not match signature")
     return value
 
+def checked_property(value, sig):
+    """
+    Check the signature of a property.
+
+    :param value: the property value
+    :param str sig: the expected signature of the value
+    :returns: value for convenience
+    :raises ValueError: if the property type is incorrect
+    """
+    if signature(value, unpack=True) != sig:
+        raise ValueError("property type does not match signature")
+    return value
 
 def _device_list(minimum):
     """

--- a/tests/dbus/manager/test_stratis.py
+++ b/tests/dbus/manager/test_stratis.py
@@ -23,9 +23,12 @@ from stratisd_client_dbus import Manager
 from stratisd_client_dbus import get_object
 
 from stratisd_client_dbus._constants import TOP_OBJECT
+from stratisd_client_dbus._implementation import ManagerSpec
 
+from .._misc import checked_property
 from .._misc import Service
 
+_PN = ManagerSpec.PropertyNames
 
 class StratisTestCase(unittest.TestCase):
     """
@@ -54,6 +57,9 @@ class StratisTestCase(unittest.TestCase):
 
         Major version number should be 0.
         """
-        version = Manager.Properties.Version(get_object(TOP_OBJECT))
+        version = checked_property(
+           Manager.Properties.Version(get_object(TOP_OBJECT)),
+           ManagerSpec.PROPERTY_SIGS[_PN.Version]
+        )
         (major, _, _) = version.split(".")
         self.assertEqual(major, "0")


### PR DESCRIPTION
Take advantage of signature() method API to type of Version property.

Signed-off-by: mulhern <amulhern@redhat.com>