### PR TITLE
Change to connect to Stratisd on the system bus

### DIFF
--- a/src/stratisd_client_dbus/_connection.py
+++ b/src/stratisd_client_dbus/_connection.py
@@ -35,7 +35,7 @@ class Bus(object):
         Get our bus.
         """
         if Bus._BUS is None:
-            Bus._BUS = dbus.SessionBus()
+            Bus._BUS = dbus.SystemBus()
 
         return Bus._BUS
 


### PR DESCRIPTION
Stratisd is changing to use the system bus, so naturally we need to
also change in order to continue working.

Signed-off-by: Andy Grover <agrover@redhat.com>