### PR TITLE
Add support for new pool size/used properties

### DIFF
--- a/src/stratisd_client_dbus/_implementation.py
+++ b/src/stratisd_client_dbus/_implementation.py
@@ -238,6 +238,8 @@ class PoolSpec(InterfaceSpec):
         """
         Name = "Name"
         Uuid = "Uuid"
+        TotalPhysicalSize = "TotalPhysicalSize"
+        TotalPhysicalUsed = "TotalPhysicalUsed"
 
     INTERFACE_NAME = 'org.storage.stratis1.pool'
 


### PR DESCRIPTION
These communicate the total size of the pool, and the total used, in
512-byte sectors. They are string properties.

Signed-off-by: Andy Grover <agrover@redhat.com>