### PR TITLE
Revert "skip Destroy2TestCase until stratisd PR #660 is merged"

### DIFF
--- a/tests/dbus/manager/test_destroy.py
+++ b/tests/dbus/manager/test_destroy.py
@@ -74,7 +74,7 @@ class Destroy1TestCase(unittest.TestCase):
         (_, rc, _) = Manager.Methods.DestroyPool(self._proxy, {'pool': "/"})
         self.assertEqual(rc, StratisdErrors.OK)
 
-@unittest.skip("skip test case until stratid PR #660 is merged")
+
 class Destroy2TestCase(unittest.TestCase):
     """
     Test 'destroy' on database which contains the given pool and an unknown


### PR DESCRIPTION
This reverts commit a4ee329da5f7ff11dcc51de1a8a53512acba0157.

stratisd PR #660 has been merged.

Signed-off-by: Andy Grover <agrover@redhat.com>